### PR TITLE
Fix link to examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ A golang client library for [AWX](https://github.com/ansible/awx) and [Ansible T
 
 ## Examples
 
-See [examples/awx](examples/awx).
+See [examples](examples).


### PR DESCRIPTION
This pull requests fixes the link to the examples directory in the root `README.md` file.