### PR TITLE
Add `.travis.yml`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: go
+
+go:
+- "1.9"
+- "1.10"
+
+go_import_path: github.com/moolitayer/awx-client-go
+
+install:
+- go get github.com/golang/glog
+
+script:
+- go build ./awx
+- for i in examples/*.go; do go build "${i}"; done

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # awx-client-go
 
+[![Build Status](https://travis-ci.org/moolitayer/awx-client-go.svg?branch=master)](https://travis-ci.org/moolitayer/awx-client-go)
+
 A golang client library for [AWX](https://github.com/ansible/awx) and [Ansible Tower](https://www.ansible.com/products/tower) REST API.
 
 ## Examples


### PR DESCRIPTION
This patch adds a simple [Travis CI](https://travis-ci.org) configurationf file that builds the client and the examples for Go 1.9 and 1.10.