### PR TITLE
Build does nothing for pkg

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,11 @@
 
 A golang client library for [AWX](https://github.com/ansible/awx) and [Ansible Tower](https://www.ansible.com/products/tower) REST API.
 
-## Build
-
-In order to build this package `glog` package is needed. Run:
-
+## Installation
+Install awx-client-go using the "go-get" command:
 ```
-go get github.com/golang/glog
-go build ./awx/ 
+go get github.com/moolitayer/golang/glog # Dependency
+go get github.com/moolitayer/awx-client-go/awx
 ```
 
 ## Examples


### PR DESCRIPTION
`go build` will creates binaries from main packages in the current
location but won't install libraries. for pkg we
should use `go install` like some other libs do[1].

Proof:
```
$ rm -rf  /home/mtayer/dev/gopath/pkg/linux_amd64/github.com/moolitayer/awx-client-go/
$ go build ./awx/
$ ll  /home/mtayer/dev/gopath/pkg/linux_amd64/github.com/moolitayer/awx-client-go/
ls: cannot access '/home/mtayer/dev/gopath/pkg/linux_amd64/github.com/moolitayer/awx-client-go/': No such file or directory
```

[1] 
https://github.com/go-redis/redis
https://github.com/gomodule/redigo
