### PR TITLE
Filter sensitive fields from debug output

### DIFF
--- a/awx/connection.go
+++ b/awx/connection.go
@@ -25,6 +25,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 
 	"github.com/golang/glog"
@@ -401,7 +402,7 @@ func (c *Connection) rawGet(path string, query url.Values) (output []byte, err e
 	if glog.V(3) {
 		glog.Info("Request headers:\n")
 		for key, val := range request.Header {
-			glog.Infof("	%s: %v", key, val)
+			glog.Infof("	%s: %v", key, filterHeader(key, val))
 		}
 	}
 	response, err := c.client.Do(request)
@@ -417,10 +418,10 @@ func (c *Connection) rawGet(path string, query url.Values) (output []byte, err e
 		return
 	}
 	if glog.V(3) {
-		glog.Infof("Response body:\n%s", c.indent(output))
+		glog.Infof("Response body:\n%s", c.indent(filterJsonBytes(output)))
 		glog.Info("Response headers:")
 		for key, val := range response.Header {
-			glog.Infof("	%s: %v", key, val)
+			glog.Infof("	%s: %v", key, filterHeader(key, val))
 		}
 
 	}
@@ -471,10 +472,10 @@ func (c *Connection) rawPost(path string, query url.Values, input []byte) (outpu
 		glog.Infof("Sending POST request to '%s'.", address)
 	}
 	if glog.V(3) {
-		glog.Infof("Request body:\n%s", c.indent(input))
+		glog.Infof("Request body:\n%s", c.indent(filterJsonBytes(input)))
 		glog.Infof("Request headers:")
 		for key, val := range request.Header {
-			glog.Infof("	%s: %v", key, val)
+			glog.Infof("	%s: %v", key, filterHeader(key, val))
 		}
 	}
 	response, err := c.client.Do(request)
@@ -490,7 +491,7 @@ func (c *Connection) rawPost(path string, query url.Values, input []byte) (outpu
 		return
 	}
 	if glog.V(3) {
-		glog.Infof("Response body:\n%s", c.indent(output))
+		glog.Infof("Response body:\n%s", c.indent(filterJsonBytes(output)))
 		glog.Info("Response headers:")
 		for key, val := range response.Header {
 			glog.Infof("	%s: %v", key, val)
@@ -536,4 +537,50 @@ func (c *Connection) indent(data []byte) []byte {
 		return data
 	}
 	return buffer.Bytes()
+}
+
+var passwordFilterRegex = regexp.MustCompile("(?i:password|token|authorization|key)")
+
+func filterJsonBytes(bytes []byte) []byte {
+	if len(bytes) == 0 {
+		return bytes
+	}
+	var jsonObj interface{}
+	err := json.Unmarshal(bytes, &jsonObj)
+	if err != nil {
+		glog.Warningf("Error parsing: %v", err)
+		return []byte{}
+	}
+	jsonObj = filterJsonObject(jsonObj)
+	ret, err := json.Marshal(jsonObj)
+	if err != nil {
+		glog.Warningf("Error encoding: %v", err)
+		return []byte{}
+	}
+	return ret
+}
+
+func filterJsonObject(object interface{}) interface{} {
+	switch object := object.(type) {
+	case map[string]interface{}: //JSON dicts
+		for key, val := range object {
+			if passwordFilterRegex.MatchString(key) {
+				object[key] = "REDACTED"
+			} else {
+				object[key] = filterJsonObject(val)
+			}
+		}
+	case []interface{}: //JSON Arrays
+		for index, val := range object {
+			object[index] = filterJsonObject(val)
+		}
+	}
+	return object
+}
+
+func filterHeader(key string, val []string) []string {
+	if passwordFilterRegex.MatchString(key) {
+		return []string{"REDACTED"}
+	}
+	return val
 }

--- a/awx/conntection_test.go
+++ b/awx/conntection_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright (c) 2018 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package awx
+
+import (
+	"testing"
+)
+
+func TestFilterHeader(t *testing.T) {
+	result := filterHeader("password", []string{"foo1"})
+	expected := "REDACTED"
+	if result[0] != expected {
+		t.Errorf("Expected %v, got %v", expected, result)
+	}
+
+	result = filterHeader("hello", []string{"foo"})
+	expected = "foo"
+	if result[0] != expected {
+		t.Errorf("Expected %v, got %v", expected, result)
+	}
+}
+
+func TestFilterJsonBytes(t *testing.T) {
+	input := []byte("{\"Password\":\"foo\"}")
+	expected := []byte("{\"Password\":\"REDACTED\"}")
+	result := filterJsonBytes(input)
+	if string(result) != string(expected) {
+		t.Errorf("Expected %s, got %s", expected, result)
+	}
+
+	input = []byte("{\"aaa\":{\"a\":\"a\",\"password\":\"foo\"}}")
+	expected = []byte("{\"aaa\":{\"a\":\"a\",\"password\":\"REDACTED\"}}")
+	result = filterJsonBytes(input)
+	if string(result) != string(expected) {
+		t.Errorf("Expected %s, got %s", expected, result)
+	}
+
+	input = []byte("{\"aaa\":[{\"password\":\"foo\"},\"bar\"]}")
+	expected = []byte("{\"aaa\":[{\"password\":\"REDACTED\"},\"bar\"]}")
+	result = filterJsonBytes(input)
+	if string(result) != string(expected) {
+		t.Errorf("Expected %s, got %s", expected, result)
+	}
+
+	input = []byte("[{\"password\":\"foo\"},\"bar\"]")
+	expected = []byte("[{\"password\":\"REDACTED\"},\"bar\"]")
+	result = filterJsonBytes(input)
+	if string(result) != string(expected) {
+		t.Errorf("Expected %s, got %s", expected, result)
+	}
+
+
+}


### PR DESCRIPTION
This PR attempts to hide passwords and tokens from the debug log.

Fixes #13

cc: @moolitayer @zgalor @nimrodshn @jhernand 