### PR TITLE
Ensure Connection respects token and bearer set in ConnectionBuilder

### DIFF
--- a/awx/connection.go
+++ b/awx/connection.go
@@ -249,6 +249,8 @@ func (b *ConnectionBuilder) Build() (c *Connection, err error) {
 	c.base = b.url
 	c.username = b.username
 	c.password = b.password
+	c.bearer = b.bearer
+	c.token = b.token
 	c.version = "v2"
 	c.client = client
 


### PR DESCRIPTION
When calling the `Build()` method to build a `Connection`, if the user uses `Token` or `Bearer` instead of `Username` and `Password`, these values are not copied over. This will result in 404s if the user attempts to launch a job template.